### PR TITLE
🧪 Add tests for buildImageQuery in generate-article.mjs

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -902,7 +902,10 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
+if (process.argv[1] === __filename) {
+  main().catch((error) => {
   console.error(error.message || error);
   process.exit(1);
 });
+}
+export { buildImageQuery };

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert";
+import { buildImageQuery } from "./generate-article.mjs";
+
+test("buildImageQuery", async (t) => {
+  await t.test("formats simple topics correctly", () => {
+    assert.strictEqual(
+      buildImageQuery("smart home automation"),
+      "electronics,smart,home,automation"
+    );
+  });
+
+  await t.test("converts uppercase to lowercase", () => {
+    assert.strictEqual(
+      buildImageQuery("Arduino Uno Tutorial"),
+      "electronics,arduino,uno,tutorial"
+    );
+  });
+
+  await t.test("removes non-alphanumeric characters but keeps dashes", () => {
+    assert.strictEqual(
+      buildImageQuery("ESP32 & IoT: The Future!"),
+      "electronics,esp32,iot,the,future"
+    );
+    assert.strictEqual(
+      buildImageQuery("lithium-ion batteries"),
+      "electronics,lithium-ion,batteries"
+    );
+  });
+
+  await t.test("handles multiple spaces and trims padding", () => {
+    assert.strictEqual(
+      buildImageQuery("  green   energy   solutions  "),
+      "electronics,green,energy,solutions"
+    );
+  });
+
+  await t.test("limits output to 6 words plus electronics", () => {
+    assert.strictEqual(
+      buildImageQuery("this is a very long topic name that exceeds the limit"),
+      "electronics,this,is,a,very,long,topic"
+    );
+  });
+
+  await t.test("handles purely symbolic input gracefully", () => {
+    assert.strictEqual(
+      buildImageQuery("!!! @@@ ###"),
+      "electronics"
+    );
+  });
+
+  await t.test("handles empty string", () => {
+    assert.strictEqual(
+      buildImageQuery(""),
+      "electronics"
+    );
+  });
+});


### PR DESCRIPTION
🎯 **What:** Adding unit tests to `buildImageQuery` which converts string topics into image search queries. In order to test this pure function without triggering the main execution side-effects, the `main()` function execution was wrapped in an `if (process.argv[1] === __filename)` guard and the function was exported.

📊 **Coverage:** Covered all critical paths of the function:
- Happy paths with normal string inputs
- Lowercasing uppercase strings
- Removing non-alphanumeric characters while preserving dashes
- Compacting multiple spaces
- Limiting the returned string list to 6 words
- Edge cases including empty inputs and purely symbolic inputs

✨ **Result:** Enhanced test coverage that catches bugs if string modification regexes or logic in `buildImageQuery` are ever broken.

---
*PR created automatically by Jules for task [14802951957612799924](https://jules.google.com/task/14802951957612799924) started by @Rsmk27*