### PR TITLE
🧪 Add tests for ensureMetaSlug function

### DIFF
--- a/scripts/ensureMetaSlug.test.mjs
+++ b/scripts/ensureMetaSlug.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { ensureMetaSlug } from "./generate-article.mjs";
+
+describe("ensureMetaSlug", () => {
+  it("should replace existing article-slug meta tag (case-insensitive)", () => {
+    const html1 = `<html><head><meta name="article-slug" content="old-slug"></head><body></body></html>`;
+    const html2 = `<html><head><MeTa  NaMe="article-slug"  ConTenT="old-slug" ></head><body></body></html>`;
+    const expected = `<html><head><meta name="article-slug" content="new-slug"></head><body></body></html>`;
+
+    assert.strictEqual(ensureMetaSlug(html1, "new-slug"), expected);
+    assert.strictEqual(ensureMetaSlug(html2, "new-slug"), expected);
+  });
+
+  it("should insert article-slug meta tag into head if missing", () => {
+    const html = `<html><head><title>Test</title></head><body></body></html>`;
+    const expected = `<html><head>\n    <meta name="article-slug" content="new-slug"><title>Test</title></head><body></body></html>`;
+
+    assert.strictEqual(ensureMetaSlug(html, "new-slug"), expected);
+  });
+
+  it("should insert article-slug meta tag into head if missing (case-insensitive head)", () => {
+    const html = `<html><HeAd><title>Test</title></head><body></body></html>`;
+    const expected = `<html><head>\n    <meta name="article-slug" content="new-slug"><title>Test</title></head><body></body></html>`;
+
+    assert.strictEqual(ensureMetaSlug(html, "new-slug"), expected);
+  });
+
+  it("should do nothing if no head and no meta tag exists", () => {
+    const html = `<html><body><div>No head tag</div></body></html>`;
+
+    assert.strictEqual(ensureMetaSlug(html, "new-slug"), html);
+  });
+});

--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -290,7 +290,7 @@ function sanitizeHtmlOutput(text) {
     .trim();
 }
 
-function ensureMetaSlug(html, slug) {
+export function ensureMetaSlug(html, slug) {
   if (/<meta\s+name="article-slug"\s+content="[^"]*"\s*>/i.test(html)) {
     return html.replace(
       /<meta\s+name="article-slug"\s+content="[^"]*"\s*>/i,
@@ -902,7 +902,9 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
🎯 **What:** The missing tests for `ensureMetaSlug` HTML replacement have been added. `scripts/generate-article.mjs` was refactored to export the function and check if it is run as the main module so the test file could import it.

📊 **Coverage:** Scenarios covered include:
- Replacing an existing `article-slug` meta tag (case-insensitive)
- Inserting an `article-slug` meta tag into `<head>` if missing
- Handling uppercase/lowercase scenarios for `<head>` tag
- Doing nothing if neither `<head>` nor the meta tag exists

✨ **Result:** Improved test coverage for `generate-article.mjs` and made the text replacement logic verified against edge cases.

---
*PR created automatically by Jules for task [17687023706184025041](https://jules.google.com/task/17687023706184025041) started by @Rsmk27*