### PR TITLE
🧹 refactor(buildArticleTemplate): simplify sequential replacements

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -136,74 +136,64 @@ async function chooseTopic() {
 }
 
 function buildArticleTemplate(html) {
-  let template = html;
+  const replacements = [
+    [
+      /<meta\s+name="description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta name="description" content="META_DESCRIPTION" />\n    <meta name="article-slug" content="ARTICLE_SLUG">'
+    ],
+    [
+      /<meta\s+name="keywords"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta name="keywords" content="TAG_1, TAG_2, TAG_3">'
+    ],
+    [
+      /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?\s*>/i,
+      '<link rel="canonical" href="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
+    ],
+    [
+      /<meta\s+property="og:url"\s+content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="og:url" content="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
+    ],
+    [
+      /<meta\s+property="og:title"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="og:title" content="ARTICLE_TITLE | RSMK Blogs">'
+    ],
+    [
+      /<meta\s+property="og:description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="og:description" content="META_DESCRIPTION">'
+    ],
+    [
+      /<meta\s+property="twitter:url"\s+content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="twitter:url" content="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
+    ],
+    [
+      /<meta\s+property="twitter:title"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="twitter:title" content="ARTICLE_TITLE | RSMK Blogs">'
+    ],
+    [
+      /<meta\s+property="twitter:description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
+      '<meta property="twitter:description" content="META_DESCRIPTION">'
+    ],
+    [
+      /<title>[\s\S]*?<\/title>/i,
+      '<title>ARTICLE_TITLE | RSMK Blogs</title>'
+    ],
+    [
+      /<div class="blog-post-meta">[\s\S]*?<\/div>/i,
+      '<div class="blog-post-meta">\n                        <span>TAG_1</span> &bull; <span>ARTICLE_DATE</span>\n                    </div>'
+    ],
+    [
+      /<h1 class="blog-post-title">[\s\S]*?<\/h1>/i,
+      '<h1 class="blog-post-title">ARTICLE_TITLE</h1>'
+    ],
+    [
+      /<div class="blog-content">[\s\S]*?<\/div>\s*<\/div>\s*<\/article>/i,
+      '<div class="blog-content">\n                    ARTICLE_BODY\n                </div>\n            </div>\n        </article>'
+    ]
+  ];
 
-  template = template.replace(
-    /<meta\s+name="description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta name="description" content="META_DESCRIPTION" />\n    <meta name="article-slug" content="ARTICLE_SLUG">'
-  );
-
-  template = template.replace(
-    /<meta\s+name="keywords"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta name="keywords" content="TAG_1, TAG_2, TAG_3">'
-  );
-
-  template = template.replace(
-    /<link\s+rel="canonical"\s+href="[^"]*"\s*\/?\s*>/i,
-    '<link rel="canonical" href="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="og:url"\s+content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="og:url" content="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="og:title"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="og:title" content="ARTICLE_TITLE | RSMK Blogs">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="og:description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="og:description" content="META_DESCRIPTION">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="twitter:url"\s+content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="twitter:url" content="https://blogs.rsmk.me/blogs/ARTICLE_SLUG.html">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="twitter:title"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="twitter:title" content="ARTICLE_TITLE | RSMK Blogs">'
-  );
-
-  template = template.replace(
-    /<meta\s+property="twitter:description"[\s\S]*?content="[^"]*"\s*\/?\s*>/i,
-    '<meta property="twitter:description" content="META_DESCRIPTION">'
-  );
-
-  template = template.replace(
-    /<title>[\s\S]*?<\/title>/i,
-    '<title>ARTICLE_TITLE | RSMK Blogs</title>'
-  );
-
-  template = template.replace(
-    /<div class="blog-post-meta">[\s\S]*?<\/div>/i,
-    '<div class="blog-post-meta">\n                        <span>TAG_1</span> &bull; <span>ARTICLE_DATE</span>\n                    </div>'
-  );
-
-  template = template.replace(
-    /<h1 class="blog-post-title">[\s\S]*?<\/h1>/i,
-    '<h1 class="blog-post-title">ARTICLE_TITLE</h1>'
-  );
-
-  template = template.replace(
-    /<div class="blog-content">[\s\S]*?<\/div>\s*<\/div>\s*<\/article>/i,
-    '<div class="blog-content">\n                    ARTICLE_BODY\n                </div>\n            </div>\n        </article>'
-  );
-
-  return template;
+  return replacements.reduce((acc, [regex, replacement]) => {
+    return acc.replace(regex, replacement);
+  }, html);
 }
 
 async function buildPrompt(topic, articleTemplateHTML, todayFormatted) {


### PR DESCRIPTION
🎯 **What:** Refactored `buildArticleTemplate` in `scripts/generate-article.mjs` to iterate over an array of replacement pairs instead of executing multiple `.replace` statements sequentially.
💡 **Why:** This reduces code duplication, improves readability, and makes it easier to add or remove replacement rules in the future by centralizing them in a single data structure processed with `Array.prototype.reduce`.
✅ **Verification:** Ran `node -c scripts/generate-article.mjs` to ensure the syntax is valid. Code review confirmed the refactor maintains the original behavior identically without introducing regressions.
✨ **Result:** Cleaner, more declarative replacement logic.

---
*PR created automatically by Jules for task [6714512992047072600](https://jules.google.com/task/6714512992047072600) started by @Rsmk27*