### PR TITLE
🧪 Add tests for extractAnthropicText

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -902,7 +902,11 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+export { extractAnthropicText };

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert";
+import { extractAnthropicText } from "./generate-article.mjs";
+
+test("extractAnthropicText tests", async (t) => {
+  await t.test("throws error if responseJson.content is not an array", () => {
+    assert.throws(
+      () => extractAnthropicText({}),
+      /Anthropic API response did not include content blocks/
+    );
+  });
+
+  await t.test("throws error if no text block is found", () => {
+    assert.throws(
+      () => extractAnthropicText({ content: [{ type: "image" }] }),
+      /Anthropic API response did not include text output/
+    );
+  });
+
+  await t.test("throws error if text block has empty/missing text property", () => {
+    assert.throws(
+      () => extractAnthropicText({ content: [{ type: "text" }] }),
+      /Anthropic API response did not include text output/
+    );
+  });
+
+  await t.test("extracts and trims text correctly", () => {
+    const response = {
+      content: [
+        { type: "image", url: "..." },
+        { type: "text", text: "  Hello World!  " }
+      ]
+    };
+    const result = extractAnthropicText(response);
+    assert.strictEqual(result, "Hello World!");
+  });
+});


### PR DESCRIPTION
* 🎯 **What:** Added tests to cover the `extractAnthropicText` function in `scripts/generate-article.mjs`. The script was refactored slightly to prevent unintended execution when imported by wrapping `main()` execution in a check ensuring it's the primary executed script, and exporting `extractAnthropicText`.
* 📊 **Coverage:** The new tests cover missing content blocks arrays, missing text output block entirely, and missing or empty text properties within text blocks, verifying that an appropriate exception is thrown. It also tests the happy path and confirms whitespace is properly trimmed from the extracted text.
* ✨ **Result:** Increased test coverage utilizing `node:test`, ensuring changes and regressions in `extractAnthropicText` are easily caught.

---
*PR created automatically by Jules for task [14426155815130061074](https://jules.google.com/task/14426155815130061074) started by @Rsmk27*