### PR TITLE
🧪 [testing improvement description] Add tests for extractMetaDescription fallback

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -625,7 +625,7 @@ function extractArticleTitle(html) {
   return "New Article";
 }
 
-function extractMetaDescription(html) {
+export function extractMetaDescription(html) {
   const match = html.match(/<meta\s+name="description"\s+content="([^"]*)"\s*\/?\s*>/i);
   if (match) {
     return match[1].trim();
@@ -902,7 +902,10 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+import { pathToFileURL } from 'node:url';
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { extractMetaDescription } from './generate-article.mjs';
+
+test('extractMetaDescription', async (t) => {
+  await t.test('returns extracted content when meta description exists', () => {
+    const html = '<html><head><meta name="description" content="This is a test description"></head><body></body></html>';
+    const result = extractMetaDescription(html);
+    assert.strictEqual(result, 'This is a test description');
+  });
+
+  await t.test('returns default fallback when meta description does not exist', () => {
+    const html = '<html><head><title>No Description</title></head><body></body></html>';
+    const result = extractMetaDescription(html);
+    assert.strictEqual(result, 'A new article from RSMK on engineering, embedded systems, and future technologies.');
+  });
+
+  await t.test('handles whitespace around meta tags correctly', () => {
+    const html = '<html><head><meta   name="description"    content="Whitespace test"   /></head><body></body></html>';
+    const result = extractMetaDescription(html);
+    assert.strictEqual(result, 'Whitespace test');
+  });
+
+  await t.test('is case insensitive for the meta description tag', () => {
+    const html = '<html><head><MeTa NaMe="DeScRiPtIoN" CoNtEnT="Case insensitive test"></head><body></body></html>';
+    const result = extractMetaDescription(html);
+    assert.strictEqual(result, 'Case insensitive test');
+  });
+
+  await t.test('trims whitespace from extracted content', () => {
+    const html = '<html><head><meta name="description" content="   Trimming test   "></head><body></body></html>';
+    const result = extractMetaDescription(html);
+    assert.strictEqual(result, 'Trimming test');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added tests for the `extractMetaDescription` function in `scripts/generate-article.mjs`, specifically verifying its fallback behavior when no meta description exists.

📊 **Coverage:** What scenarios are now tested
- Happy path: HTML with a valid meta description tag.
- Fallback path: HTML without a meta description tag returns the expected default text.
- Edge cases: HTML with whitespace around tags, different attribute casing, and trims whitespace from the extracted content.

*Implementation detail:* Modifying the execution of `main()` in the script so that it's skipped during test imports to make the ES module correctly testable without side-effects.

✨ **Result:** The improvement in test coverage
The module can now be safely imported and tested. The `extractMetaDescription` logic is verified against the default Node.js test runner.

---
*PR created automatically by Jules for task [1650813313459531365](https://jules.google.com/task/1650813313459531365) started by @Rsmk27*