### PR TITLE
🧪 Add tests for extractReturnedSlug

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -902,7 +902,11 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+export { extractReturnedSlug, topicToSlug, extractArticleTitle };

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { extractReturnedSlug, topicToSlug, extractArticleTitle } from "./generate-article.mjs";
+
+test("extractReturnedSlug - should extract slug from meta tag", () => {
+  const html = `
+    <html>
+      <head>
+        <meta name="article-slug" content="my-test-slug">
+      </head>
+      <body></body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "my-test-slug");
+});
+
+test("extractReturnedSlug - should format slug using topicToSlug when extracted from meta tag", () => {
+  const html = `
+    <html>
+      <head>
+        <meta name="article-slug" content="My Test Slug!! ">
+      </head>
+      <body></body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "my-test-slug");
+});
+
+test("extractReturnedSlug - should fallback to extracting from h1 with blog-post-title class", () => {
+  const html = `
+    <html>
+      <head></head>
+      <body>
+        <h1 class="blog-post-title">My Awesome Article Title</h1>
+      </body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "my-awesome-article-title");
+});
+
+test("extractReturnedSlug - should format h1 title to slug", () => {
+  const html = `
+    <html>
+      <head></head>
+      <body>
+        <h1 class="blog-post-title">  Some Title with <span>HTML</span> tags!  </h1>
+      </body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "some-title-with-html-tags");
+});
+
+test("extractReturnedSlug - should fallback to extracting from title tag if no meta or h1", () => {
+  const html = `
+    <html>
+      <head>
+        <title>Another Great Post | RSMK Blogs</title>
+      </head>
+      <body></body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "another-great-post");
+});
+
+test("extractReturnedSlug - should format title tag to slug", () => {
+  const html = `
+    <html>
+      <head>
+        <title>  Another Great Post!! | RSMK Blog</title>
+      </head>
+      <body></body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "another-great-post");
+});
+
+test("extractReturnedSlug - should return fallback slug if no valid tags exist", () => {
+  const html = `
+    <html>
+      <head></head>
+      <body>
+        <h1>Just a regular h1</h1>
+      </body>
+    </html>
+  `;
+  const result = extractReturnedSlug(html);
+  assert.equal(result, "new-article");
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `extractReturnedSlug` function to verify it correctly parses slugs from HTML strings. This function now has good coverage for both normal usage and edge cases.
📊 **Coverage:** Covered extracting from meta tags, fallback to H1 tags, fallback to title tags, and default empty state fallbacks. Tested `topicToSlug` parsing rules correctly apply.
✨ **Result:** Improved test coverage and reliability for string processing.

---
*PR created automatically by Jules for task [10076889415949539818](https://jules.google.com/task/10076889415949539818) started by @Rsmk27*