### PR TITLE
🧪 Add tests for extractPrimaryTag extraction

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -902,7 +902,11 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+export { extractPrimaryTag };

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert";
+import { extractPrimaryTag } from "./generate-article.mjs";
+
+test("extractPrimaryTag extracts a single tag", () => {
+  const html = '<meta name="keywords" content="javascript">';
+  assert.strictEqual(extractPrimaryTag(html), "javascript");
+});
+
+test("extractPrimaryTag extracts the first tag from multiple comma-separated tags", () => {
+  const html = '<meta name="keywords" content="javascript, web development, coding">';
+  assert.strictEqual(extractPrimaryTag(html), "javascript");
+});
+
+test("extractPrimaryTag returns null when meta keywords is missing", () => {
+  const html = '<html><head><title>Test</title></head><body>Hello</body></html>';
+  assert.strictEqual(extractPrimaryTag(html), null);
+});
+
+test("extractPrimaryTag returns null when content is empty", () => {
+  const html = '<meta name="keywords" content="">';
+  assert.strictEqual(extractPrimaryTag(html), null);
+});
+
+test("extractPrimaryTag returns null when content is only whitespace or empty commas", () => {
+  const html = '<meta name="keywords" content=" ,  ,, ">';
+  assert.strictEqual(extractPrimaryTag(html), null);
+});
+
+test("extractPrimaryTag handles variations in spacing, case, and self-closing tags", () => {
+  const html = '<META   name="keywords"    content="Tag1, Tag2" />';
+  assert.strictEqual(extractPrimaryTag(html), "Tag1");
+});
+
+test("extractPrimaryTag trims whitespace around the primary tag", () => {
+  const html = '<meta name="keywords" content="  padded tag  , another tag">';
+  assert.strictEqual(extractPrimaryTag(html), "padded tag");
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The 'extractPrimaryTag' function in 'scripts/generate-article.mjs' was missing unit tests. 
The script was also running 'main()' unconditionally upon import, which prevented easy testing.
We resolved this by exporting the function, checking 'process.argv[1]' to safely only run 'main()' on direct execution, and wrote a test suite for 'extractPrimaryTag'.

📊 **Coverage:** What scenarios are now tested
- Valid HTML with a single tag
- Multiple comma-separated tags (extraction of the first tag)
- Missing meta keywords
- Empty meta keywords
- Content with only whitespace or empty commas
- Variations in spacing, case, and self-closing tags
- Trimming whitespace around the extracted tag

✨ **Result:** The improvement in test coverage
The string splitting and extraction logic is now reliably verified with Node.js built-in 'node:test' runner. This adds an automated safety net to prevent regressions when modifying the extraction function.

---
*PR created automatically by Jules for task [9918130730408177946](https://jules.google.com/task/9918130730408177946) started by @Rsmk27*