### PR TITLE
🧹 Refactor fetchAndSaveTopicImage to use lazy evaluation strategies

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -442,40 +442,31 @@ async function findWikipediaTopicImage(topic) {
 }
 
 async function fetchAndSaveTopicImage(topic, slug) {
-  const candidateUrls = [];
-
-  try {
-    const commonsCandidate = await findRelevantCommonsImage(topic);
-    if (commonsCandidate) {
-      if (commonsCandidate.relevance >= 0.34) {
-        candidateUrls.push(commonsCandidate.url);
-        console.log(`Wikimedia image relevance score: ${commonsCandidate.relevance.toFixed(2)}`);
-      } else {
-        // Keep a low-score Wikimedia candidate as a fallback before synthetic generation.
-        candidateUrls.push(commonsCandidate.url);
-        console.log(`Wikimedia low relevance fallback score: ${commonsCandidate.relevance.toFixed(2)}`);
+  const imageStrategies = [
+    async () => {
+      const candidate = await findRelevantCommonsImage(topic);
+      if (candidate) {
+        if (candidate.relevance >= 0.34) {
+          console.log(`Wikimedia image relevance score: ${candidate.relevance.toFixed(2)}`);
+        } else {
+          console.log(`Wikimedia low relevance fallback score: ${candidate.relevance.toFixed(2)}`);
+        }
+        return candidate.url;
       }
-    }
-  } catch {
-    // Ignore Wikimedia lookup failures and continue with prompt-based fallback.
-  }
-
-  try {
-    const wikipediaImage = await findWikipediaTopicImage(topic);
-    if (wikipediaImage) {
-      candidateUrls.push(wikipediaImage);
-    }
-  } catch {
-    // Ignore Wikipedia lookup failures.
-  }
-
-  // Prompt-based fallback using exact topic tokens.
-  candidateUrls.push(`https://image.pollinations.ai/prompt/${encodeURIComponent(`${topic} electronics technology photo realistic`)}`);
-  candidateUrls.push(`https://source.unsplash.com/1600x900/?${encodeURIComponent(buildImageQuery(topic))}&sig=${Date.now()}`);
+      return null;
+    },
+    async () => findWikipediaTopicImage(topic),
+    async () => `https://image.pollinations.ai/prompt/${encodeURIComponent(`${topic} electronics technology photo realistic`)}`,
+    async () => `https://source.unsplash.com/1600x900/?${encodeURIComponent(buildImageQuery(topic))}&sig=${Date.now()}`
+  ];
 
   let lastError = "";
-  for (const imageUrl of candidateUrls) {
+
+  for (const strategy of imageStrategies) {
     try {
+      const imageUrl = await strategy();
+      if (!imageUrl) continue;
+
       const response = await fetch(imageUrl, {
         headers: {
           "User-Agent": "rsmkblogs-article-generator/1.0"


### PR DESCRIPTION
🎯 **What:** Replaced the sequential array population and sequential fetching with an array of asynchronous fallback strategy closures, evaluating candidate URLs lazily.
💡 **Why:** This improves maintainability and readability by avoiding heavily nested `try-catch` blocks inside `fetchAndSaveTopicImage` and grouping url generation and error handling conceptually.
✅ **Verification:** Handled successfully running generation and backfill without throwing unhandled exceptions.
✨ **Result:** Better error resilience and more explicit fallback strategy.

---
*PR created automatically by Jules for task [3533453752273702457](https://jules.google.com/task/3533453752273702457) started by @Rsmk27*