### PR TITLE
🧪 Add tests for escapeHtml function

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -46,7 +46,7 @@ function topicToSlug(topic) {
     .replace(/(^-|-$)/g, "");
 }
 
-function escapeHtml(value) {
+export function escapeHtml(value) {
   return String(value)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -902,7 +902,9 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert";
+import { escapeHtml } from "./generate-article.mjs";
+
+test("escapeHtml handles basic escaping", () => {
+  assert.strictEqual(escapeHtml("hello"), "hello");
+  assert.strictEqual(escapeHtml("a&b"), "a&amp;b");
+  assert.strictEqual(escapeHtml("a<b"), "a&lt;b");
+  assert.strictEqual(escapeHtml("a>b"), "a&gt;b");
+  assert.strictEqual(escapeHtml('a"b'), "a&quot;b");
+  assert.strictEqual(escapeHtml("a'b"), "a&#39;b");
+});
+
+test("escapeHtml handles multiple occurrences and combinations", () => {
+  assert.strictEqual(
+    escapeHtml("<script>alert('XSS & \"test\"')</script>"),
+    "&lt;script&gt;alert(&#39;XSS &amp; &quot;test&quot;&#39;)&lt;/script&gt;"
+  );
+  assert.strictEqual(escapeHtml("&&&&"), "&amp;&amp;&amp;&amp;");
+});
+
+test("escapeHtml handles non-string inputs safely by stringifying", () => {
+  assert.strictEqual(escapeHtml(123), "123");
+  assert.strictEqual(escapeHtml(null), "null");
+  assert.strictEqual(escapeHtml(undefined), "undefined");
+});
+
+test("escapeHtml handles empty string", () => {
+  assert.strictEqual(escapeHtml(""), "");
+});


### PR DESCRIPTION
🎯 **What:** The missing tests for the `escapeHtml` pure function in `scripts/generate-article.mjs` have been implemented. The script was slightly refactored to conditionally run the main script block only when executed directly and to export the function for testing.
📊 **Coverage:** The new `scripts/generate-article.test.mjs` test file covers:
- Normal strings without special characters.
- HTML entities (`&`, `<`, `>`, `"`, `'`).
- Multiple occurrences of entities and combined strings (e.g. XSS strings).
- Non-string inputs like numbers, null, and undefined (converted to strings safely).
- Empty strings.
✨ **Result:** Test coverage for `escapeHtml` is now robust, utilizing the built-in `node:test` and `node:assert` modules, making the function completely safe for future refactoring and integration changes.

---
*PR created automatically by Jules for task [7181831676280041337](https://jules.google.com/task/7181831676280041337) started by @Rsmk27*