### PR TITLE
🔒 Security fix: Add rel='noopener noreferrer' to external links

### DIFF
--- a/about.html
+++ b/about.html
@@ -186,7 +186,7 @@
                     <a href="index.html" class="logo" style="font-size: 1.5rem;">RSMK<span>.</span></a>
                     <p>Building Future Technologies</p>
                     <div class="footer-socials">
-                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" aria-label="Portfolio"><svg
+                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" rel="noopener noreferrer" aria-label="Portfolio"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
@@ -197,7 +197,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.linkedin.com/in/rsmk27/" class" title="Linked="footer-social-linkIn"
-                            target="_blank" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -207,7 +207,7 @@
                                 <circle cx="4" cy="4" r="2"></circle>
                             </svg></a>
                         <a href="https://github.com/Rsmk27" class="footer-social-link" title="GitHub"
-                            target="_blank" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -215,7 +215,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.instagram.com/rsmk_27/" class="footer-social-link" title="Instagram"
-                            target="_blank" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
@@ -223,12 +223,12 @@
                                 <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
                             </svg></a>
                         <a href="https://x.com/SrinivasManik20" class="footer-social-link" title="X (Twitter)"
-                            target="_blank" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 fill="currentColor" viewBox="0 0 16 16">
                                 <path
                                     d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865l8.875 11.633Z" />
                             </svg></a>
-                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" aria-label="Telegram"><svg
+                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" rel="noopener noreferrer" aria-label="Telegram"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">

--- a/blogs.html
+++ b/blogs.html
@@ -592,7 +592,7 @@
                     <a href="index.html" class="logo" style="font-size: 1.5rem;">RSMK<span>.</span></a>
                     <p>Building Future Technologies</p>
                     <div class="footer-socials">
-                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" aria-label="Portfolio"><svg
+                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" rel="noopener noreferrer" aria-label="Portfolio"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
@@ -603,7 +603,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.linkedin.com/in/rsmk27/" class="footer-social-link" title="LinkedIn"
-                            target="_blank" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -613,7 +613,7 @@
                                 <circle cx="4" cy="4" r="2"></circle>
                             </svg></a>
                         <a href="https://github.com/Rsmk27" class="footer-social-link" title="GitHub"
-                            target="_blank" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -621,7 +621,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.instagram.com/rsmk_27/" class="footer-social-link" title="Instagram"
-                            target="_blank" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
@@ -629,12 +629,12 @@
                                 <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
                             </svg></a>
                         <a href="https://x.com/SrinivasManik20" class="footer-social-link" title="X (Twitter)"
-                            target="_blank" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 fill="currentColor" viewBox="0 0 16 16">
                                 <path
                                     d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865l8.875 11.633Z" />
                             </svg></a>
-                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" aria-label="Telegram"><svg
+                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" rel="noopener noreferrer" aria-label="Telegram"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">

--- a/blogs/5g-6g-tech.html
+++ b/blogs/5g-6g-tech.html
@@ -90,7 +90,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/ai-drones.html
+++ b/blogs/ai-drones.html
@@ -82,7 +82,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/arduino-guide.html
+++ b/blogs/arduino-guide.html
@@ -110,7 +110,7 @@ void loop() {
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/arduino-mega.html
+++ b/blogs/arduino-mega.html
@@ -183,7 +183,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/arduino-nano.html
+++ b/blogs/arduino-nano.html
@@ -319,7 +319,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/arduino-uno.html
+++ b/blogs/arduino-uno.html
@@ -191,7 +191,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/careers.html
+++ b/blogs/careers.html
@@ -94,7 +94,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/esp8266.html
+++ b/blogs/esp8266.html
@@ -180,7 +180,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/ev-charging.html
+++ b/blogs/ev-charging.html
@@ -93,7 +93,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/renewable-energy.html
+++ b/blogs/renewable-energy.html
@@ -82,7 +82,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/semiconductors.html
+++ b/blogs/semiconductors.html
@@ -78,7 +78,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/blogs/smart-home.html
+++ b/blogs/smart-home.html
@@ -85,7 +85,7 @@
     <footer>
         <div class="container">
             <div class="footer-bottom">
-                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank"
+                <p>&copy; 2025 RSMK Blogs. All rights reserved. <a href="https://rsmk.me" target="_blank" rel="noopener noreferrer"
                         class="glow-text">BY RSMK</a></p>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -324,7 +324,7 @@
                     <a href="index.html" class="logo" style="font-size: 1.5rem;">RSMK<span>.</span></a>
                     <p>Building Future Technologies</p>
                     <div class="footer-socials">
-                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" aria-label="Portfolio"><svg
+                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" rel="noopener noreferrer" aria-label="Portfolio"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
@@ -335,7 +335,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.linkedin.com/in/rsmk27/" class="footer-social-link" title="LinkedIn"
-                            target="_blank" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -345,7 +345,7 @@
                                 <circle cx="4" cy="4" r="2"></circle>
                             </svg></a>
                         <a href="https://github.com/Rsmk27" class="footer-social-link" title="GitHub"
-                            target="_blank" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -353,7 +353,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.instagram.com/rsmk_27/" class="footer-social-link" title="Instagram"
-                            target="_blank" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
@@ -361,12 +361,12 @@
                                 <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
                             </svg></a>
                         <a href="https://x.com/SrinivasManik20" class="footer-social-link" title="X (Twitter)"
-                            target="_blank" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 fill="currentColor" viewBox="0 0 16 16">
                                 <path
                                     d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865l8.875 11.633Z" />
                             </svg></a>
-                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" aria-label="Telegram"><svg
+                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" rel="noopener noreferrer" aria-label="Telegram"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">

--- a/projects.html
+++ b/projects.html
@@ -246,7 +246,7 @@
                     <a href="index.html" class="logo" style="font-size: 1.5rem;">RSMK<span>.</span></a>
                     <p>Building Future Technologies</p>
                     <div class="footer-socials">
-                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" aria-label="Portfolio"><svg
+                        <a href="https://rsmk.me" class="footer-social-link" title="Portfolio" target="_blank" rel="noopener noreferrer" aria-label="Portfolio"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">
@@ -257,7 +257,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.linkedin.com/in/rsmk27/" class="footer-social-link" title="LinkedIn"
-                            target="_blank" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -267,7 +267,7 @@
                                 <circle cx="4" cy="4" r="2"></circle>
                             </svg></a>
                         <a href="https://github.com/Rsmk27" class="footer-social-link" title="GitHub"
-                            target="_blank" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <path
@@ -275,7 +275,7 @@
                                 </path>
                             </svg></a>
                         <a href="https://www.instagram.com/rsmk_27/" class="footer-social-link" title="Instagram"
-                            target="_blank" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="Instagram"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                                 stroke-linecap="round" stroke-linejoin="round">
                                 <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
@@ -283,12 +283,12 @@
                                 <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
                             </svg></a>
                         <a href="https://x.com/SrinivasManik20" class="footer-social-link" title="X (Twitter)"
-                            target="_blank" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                            target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                                 fill="currentColor" viewBox="0 0 16 16">
                                 <path
                                     d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865l8.875 11.633Z" />
                             </svg></a>
-                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" aria-label="Telegram"><svg
+                        <a href="https://t.me/RSMK_27" class="footer-social-link" title="Telegram" target="_blank" rel="noopener noreferrer" aria-label="Telegram"><svg
                                 xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                 fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                 stroke-linejoin="round">


### PR DESCRIPTION
🎯 **What:** 
Added the `rel="noopener noreferrer"` attribute to all external links (`target="_blank"`) across all HTML files in the repository. The reported vulnerability was on `about.html:226` but 35 other identical instances were present and also fixed.

⚠️ **Risk:** 
If an external link does not include `rel="noopener"`, the newly opened window or tab gains partial control over the original page via the `window.opener` object. A malicious site in the new tab could execute cross-site scripting (XSS), potentially changing the `location` of the original tab to redirect the user to a phishing page (an attack known as reverse tabnabbing).

🛡️ **Solution:** 
Appending `rel="noopener noreferrer"` instructs the browser to sever the connection between the original page and the newly opened external page. This blocks the new page's access to the `window.opener` object completely and prevents the referrer header from being sent, thereby fully mitigating the security risk.

---
*PR created automatically by Jules for task [6183090692153011701](https://jules.google.com/task/6183090692153011701) started by @Rsmk27*