### PR TITLE
🧪 Add tests for tokenizeForRelevance

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -336,7 +336,7 @@ function buildImageQuery(topic) {
   return ["electronics", ...words].join(",");
 }
 
-function tokenizeForRelevance(text) {
+export function tokenizeForRelevance(text) {
   const stopWords = new Set([
     "the", "and", "for", "with", "from", "that", "this", "your", "into", "about", "using", "guide",
     "how", "what", "why", "new", "best", "more", "less", "over", "under", "versus", "vs", "practical"
@@ -902,7 +902,9 @@ async function main() {
   console.log("Topic usage updated: scripts/used-topics.json");
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/scripts/generate-article.test.mjs
+++ b/scripts/generate-article.test.mjs
@@ -1,0 +1,50 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { tokenizeForRelevance } from './generate-article.mjs';
+
+describe('tokenizeForRelevance', () => {
+  test('returns a Set of tokens', () => {
+    const result = tokenizeForRelevance('hello world');
+    assert.ok(result instanceof Set);
+  });
+
+  test('converts tokens to lowercase and trims them', () => {
+    const result = tokenizeForRelevance(' Hello World ');
+    assert.deepStrictEqual(Array.from(result).sort(), ['hello', 'world']);
+  });
+
+  test('filters out short words (length <= 2)', () => {
+    const result = tokenizeForRelevance('a to the box ox dog');
+    assert.deepStrictEqual(Array.from(result).sort(), ['box', 'dog']);
+  });
+
+  test('filters out stop words', () => {
+    const text = 'the and for with from that this your into about using guide how what why new best more less over under versus vs practical hello world';
+    const result = tokenizeForRelevance(text);
+    // Only "hello" and "world" should remain after filtering out all those stop words
+    assert.deepStrictEqual(Array.from(result).sort(), ['hello', 'world']);
+  });
+
+  test('handles punctuation and special characters by replacing them with space', () => {
+    // Expected: lowercase, replace special chars, filter length > 2
+    const result = tokenizeForRelevance('Hello, world! 100% pure... javascript-magic?');
+    // Result tokens: hello, world, 100, pure, javascript-magic
+    assert.deepStrictEqual(Array.from(result).sort(), ['100', 'hello', 'javascript-magic', 'pure', 'world']);
+  });
+
+  test('returns empty Set for empty strings, null, or undefined', () => {
+    assert.strictEqual(tokenizeForRelevance('').size, 0);
+    assert.strictEqual(tokenizeForRelevance(null).size, 0);
+    assert.strictEqual(tokenizeForRelevance(undefined).size, 0);
+  });
+
+  test('handles multiple consecutive spaces and newlines', () => {
+    const result = tokenizeForRelevance('super    cool\n\n\nstuff\t\there');
+    assert.deepStrictEqual(Array.from(result).sort(), ['cool', 'here', 'stuff', 'super']);
+  });
+
+  test('handles duplicated words, keeping only unique tokens', () => {
+    const result = tokenizeForRelevance('cats and dogs cats dogs');
+    assert.deepStrictEqual(Array.from(result).sort(), ['cats', 'dogs']);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of test coverage for the `tokenizeForRelevance` pure function within the `scripts/generate-article.mjs` blog generation script. To make this testable without triggering the main script body as a side-effect, the function was exported and the `main()` call was wrapped in a conditional execution guard (`if (import.meta.url === \`file://${process.argv[1]}\`)`).

📊 **Coverage:** What scenarios are now tested
A new test file `scripts/generate-article.test.mjs` was created, utilizing the native `node:test` framework. Tests now cover:
- Expected output type (`Set`).
- String preprocessing (lowercasing, trimming).
- Filtering out words with 2 or fewer characters.
- Removal of predefined stop words.
- Cleaning of punctuation and non-alphanumeric characters.
- Edge cases including passing `null`, `undefined`, and empty strings.
- Graceful handling of multiple concurrent spacing/newlines.
- Removal of duplicate tokens.

✨ **Result:** The improvement in test coverage
We now have reliable, fast, and deterministic tests for `tokenizeForRelevance`. This significantly improves the codebase's reliability by ensuring that the relevance scoring logic won't break unnoticed when updated. The native node testing execution successfully runs and passes all 8 test assertions.

---
*PR created automatically by Jules for task [8314555115685100013](https://jules.google.com/task/8314555115685100013) started by @Rsmk27*