### PR TITLE
🧹 [code health improvement] Refactor fallback image providers

### DIFF
--- a/scripts/generate-article.mjs
+++ b/scripts/generate-article.mjs
@@ -23,6 +23,11 @@ const groqEndpoint = "https://api.groq.com/openai/v1/chat/completions";
 const groqDefaultModel = "llama-3.3-70b-versatile";
 const siteBaseUrl = "https://blogs.rsmk.me";
 
+const FALLBACK_IMAGE_PROVIDERS = [
+  (topic) => `https://image.pollinations.ai/prompt/${encodeURIComponent(`${topic} electronics technology photo realistic`)}`,
+  (topic) => `https://source.unsplash.com/1600x900/?${encodeURIComponent(buildImageQuery(topic))}&sig=${Date.now()}`
+];
+
 function formatLongDate(date = new Date()) {
   return new Intl.DateTimeFormat("en-US", {
     month: "long",
@@ -469,9 +474,10 @@ async function fetchAndSaveTopicImage(topic, slug) {
     // Ignore Wikipedia lookup failures.
   }
 
-  // Prompt-based fallback using exact topic tokens.
-  candidateUrls.push(`https://image.pollinations.ai/prompt/${encodeURIComponent(`${topic} electronics technology photo realistic`)}`);
-  candidateUrls.push(`https://source.unsplash.com/1600x900/?${encodeURIComponent(buildImageQuery(topic))}&sig=${Date.now()}`);
+  // Prompt-based fallback using configured providers.
+  for (const provider of FALLBACK_IMAGE_PROVIDERS) {
+    candidateUrls.push(provider(topic));
+  }
 
   let lastError = "";
   for (const imageUrl of candidateUrls) {


### PR DESCRIPTION
🎯 **What:** Extracted hardcoded prompt-based fallback image URLs into a configuration-driven array `FALLBACK_IMAGE_PROVIDERS`.
💡 **Why:** This improves maintainability by removing magic string/number setups (like `1600x900`) and makes adding or modifying fallback providers significantly easier and more extensible without polluting the core logic loop.
✅ **Verification:** Ran `node --check` and verified syntax was valid. Verified functionality isn't broken via mocked API requests and code inspection.
✨ **Result:** Cleaner, more maintainable code structure for image fetching fallbacks.

---
*PR created automatically by Jules for task [10707139685302756607](https://jules.google.com/task/10707139685302756607) started by @Rsmk27*